### PR TITLE
[WIP]商品詳細表示（サーバーサイド ）の実装

### DIFF
--- a/app/assets/javascripts/products_detail.js
+++ b/app/assets/javascripts/products_detail.js
@@ -2,6 +2,8 @@
 
 $(function(){
   let views = $(".small-view");
+  $('.inactive:first').removeClass("inactive").addClass("active");
+  
   $('.imagebox-left__imagebox-bottom img').hover(function(){
     $('.active').removeClass("active").addClass("inactive");
     let num = views.index(this);

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,10 @@ class ProductsController < ApplicationController
   end
 
   def show
+    # 実際に表示することができるか確認するために、id: 1 を入力してます
+    @product = Product.find(1)
+    # @product = Product.find(params[:id])
+
   end
 
   def buy_confirm

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
+  has_many_attached :images
   belongs_to :user
   belongs_to :brand
   belongs_to :term

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -4,21 +4,29 @@
 
 .detail-container
   %h1
-    ワイドパンツ
+    = @product.name
   .detail-container__ditail-wrap
 
     .imagebox-left
       .imagebox-left__imagebox-large
-        = image_tag "/sample_images/bag_sample1.jpg", width: "300", height: "225", class: "active"
-        = image_tag "/sample_images/bag_sample2.jpg", width: "300", height: "225", class: "inactive"
-        = image_tag "/sample_images/bag_sample3.jpg", width: "300", height: "225", class: "inactive"
-        = image_tag "/sample_images/bag_sample4.jpg", width: "300", height: "225", class: "inactive"
+
+        - if @product.images.attached?
+          - @product.images.each do |image|
+            = image_tag image, width: "300", height: "225", class: "inactive"
+            
+
+
+        - if @product.images.attached?
+          - @product.images.each do |image|
+            = image_tag image, width: "300", width: "300", height: "225", class: "inactive"
+            %br/
+
 
       .imagebox-left__imagebox-bottom
-        = image_tag "/sample_images/bag_sample1.jpg", width: "60", height: "60", class: 'small-view'
-        = image_tag "/sample_images/bag_sample2.jpg", width: "60", height: "60", class: 'small-view'
-        = image_tag "/sample_images/bag_sample3.jpg", width: "60", height: "60", class: 'small-view'
-        = image_tag "/sample_images/bag_sample4.jpg", width: "60", height: "60", class: 'small-view'
+        - if @product.images.attached?
+          - @product.images.each do |image|
+            = image_tag image, width: "60", height: "60", class: 'small-view'
+            %br/
 
 
 
@@ -29,7 +37,7 @@
             出品者
           %td
             = link_to "#" do
-              ○○○○
+              = @product.user.nickname
             .face-icon
               %span
                 %i.fas.fa-grin.icon-grin
@@ -48,52 +56,55 @@
             カテゴリー
           %td.td-category
             = link_to "#" do
-              レディース
+              = @product.category.parent.parent.name
             = link_to "#" do
-              ＞バッグ
+              >
+              = @product.category.parent.name
             = link_to "#" do
-              ＞ショルダーバッグ
+              >
+              = @product.category.name
 
         %tr.tr-detail
           %th.others
             ブランド
           %td
             = link_to "#" do
-              ○○○○
+              = @product.brand.name
 
         %tr.tr-detail
           %th.others
             商品の状態
           %td
-            目立った傷や汚れなし
+            = @product.condition.name
 
         %tr.tr-detail
           %th.others
             発送料の負担
           %td
-            送料込み(出品者負担)
+            = @product.delivery.name
 
         %tr.tr-detail
           %th.others
             発送の方法
           %td
-            らくらくメルカリ便
+            = @product.shipping.name
 
         %tr.tr-detail
           %th.others
             発送元地域
           %td
             = link_to "#" do
-              福岡県
+              = @product.fromprefecture.name
         %tr.tr-detail
           %th.others
             発送の目安
           %td
-            2~3日で発送
+            = @product.term.name
 
   .price-box
     %span.price
-      ¥7,500
+      ¥
+      = @product.price
     %span.tax
       (税込)
     %span.deliver
@@ -103,7 +114,7 @@
     購入画面に進む
   .item-description
     %p
-      カラーはベージュです。ポケットがたくさん有りとても使いやすいバックです。傷や汚れなどありませんが写真をご確認の上、中古品であるということをご理解いただきご購入をお願いします。
+      = @product.description
 
   .button-container
     .button-container__button-two


### PR DESCRIPTION
# what 
商品詳細表示ページのサーバーサイドの実装

# why
ユーザーが商品の詳細ページを見ることができるため

# how
まだ、出品ページ、一覧ページなどが未実装です。
mysql の中に,product(id:1)を作成し、その情報を
表示させてます。
商品詳細は、
/views/products/show.html.haml
です。
